### PR TITLE
会員登録画面の実装〜Laravelのミドルウェアを使用してみる

### DIFF
--- a/sportweb/app/Http/Controllers/UsersController.php
+++ b/sportweb/app/Http/Controllers/UsersController.php
@@ -6,50 +6,8 @@ use Illuminate\Http\Request;
 
 class UsersController extends Controller
 {
-    public function register()
+    public function register(Request $request)
     {
-        $form_elements = [
-            ['label_attribute_name' => 'name', 
-            'label_content' => 'ユーザーネーム', 
-            'input_attribute_id' => '', 
-            'input_attribute_type' => 'text', 
-            'input_attribute_name' => 'name', 
-            'input_attribute_value' => '', 
-            'input_attribute_placeholder' => 'ユーザーネームを設定し記入', 
-            'info_attribute_id' => '', 
-            'info_content' => ''
-            ], 
-            ['label_attribute_name' => 'email', 
-            'label_content' => 'メールアドレス', 
-            'input_attribute_id' => '',  
-            'input_attribute_type' => 'text', 
-            'input_attribute_name' => 'email', 
-            'input_attribute_value' => '', 
-            'input_attribute_placeholder' => 'メールアドレスを記入', 
-            'info_attribute_id' => '', 
-            'info_content' => ''
-            ], 
-            ['label_attribute_name' => 'password', 
-            'label_content' => 'パスワード', 
-            'input_attribute_id' => 'password', 
-            'input_attribute_type' => 'password', 
-            'input_attribute_name' => 'password', 
-            'input_attribute_value' => '', 
-            'input_attribute_placeholder' => 'パスワードを設定し記入', 
-            'info_attribute_id' => 'password_validation', 
-            'info_content' => 'パスワードは8文字以上で設定して下さい。'
-            ], 
-            ['label_attribute_name' => 'password_confirmation', 
-            'label_content' => 'パスワードの再入力', 
-            'input_attribute_id' => 'password_confirmation', 
-            'input_attribute_type' => 'password', 
-            'input_attribute_name' => 'password_confirmation', 
-            'input_attribute_value' => '', 
-            'input_attribute_placeholder' => '確認のためパスワードを再記入', 
-            'info_attribute_id' => 'password_confirmation_validation', 
-            'info_content' => 'パスワードが一致しません。'
-            ], 
-        ];
-        return view('users.register', ['form_elements' => $form_elements]);
+        return view('users.register', ['form_elements' => $request->form_elements]);
     }
 }

--- a/sportweb/app/Http/Middleware/UserRegisterFormMiddleware.php
+++ b/sportweb/app/Http/Middleware/UserRegisterFormMiddleware.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class UserRegisterFormMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $form_elements = [
+            ['label_attribute_name' => 'name', 
+            'label_content' => 'ユーザーネーム', 
+            'input_attribute_id' => '', 
+            'input_attribute_type' => 'text', 
+            'input_attribute_name' => 'name', 
+            'input_attribute_value' => '', 
+            'input_attribute_placeholder' => 'ユーザーネームを設定し記入', 
+            'info_attribute_id' => '', 
+            'info_content' => ''
+            ], 
+            ['label_attribute_name' => 'email', 
+            'label_content' => 'メールアドレス', 
+            'input_attribute_id' => '',  
+            'input_attribute_type' => 'text', 
+            'input_attribute_name' => 'email', 
+            'input_attribute_value' => '', 
+            'input_attribute_placeholder' => 'メールアドレスを記入', 
+            'info_attribute_id' => '', 
+            'info_content' => ''
+            ], 
+            ['label_attribute_name' => 'password', 
+            'label_content' => 'パスワード', 
+            'input_attribute_id' => 'password', 
+            'input_attribute_type' => 'password', 
+            'input_attribute_name' => 'password', 
+            'input_attribute_value' => '', 
+            'input_attribute_placeholder' => 'パスワードを設定し記入', 
+            'info_attribute_id' => 'password_validation', 
+            'info_content' => 'パスワードは8文字以上で設定して下さい。'
+            ], 
+            ['label_attribute_name' => 'password_confirmation', 
+            'label_content' => 'パスワードの再入力', 
+            'input_attribute_id' => 'password_confirmation', 
+            'input_attribute_type' => 'password', 
+            'input_attribute_name' => 'password_confirmation', 
+            'input_attribute_value' => '', 
+            'input_attribute_placeholder' => '確認のためパスワードを再記入', 
+            'info_attribute_id' => 'password_confirmation_validation', 
+            'info_content' => 'パスワードが一致しません。'
+            ], 
+        ];
+
+        $request->merge(['form_elements' => $form_elements]);
+
+        return $next($request);
+    }
+}

--- a/sportweb/resources/views/users/register.blade.php
+++ b/sportweb/resources/views/users/register.blade.php
@@ -6,7 +6,7 @@
     <script src="/js/users.js"></script>
 @endsection
 
-@section('content') <!-- TODO: インデント要整頓 -->
+@section('content')
 
     @component('components.content_header')
         @slot('content_title', '新規会員登録')

--- a/sportweb/routes/web.php
+++ b/sportweb/routes/web.php
@@ -13,4 +13,6 @@
 
 Route::get('top', 'TopsController@index');
 
-Route::get('/users/register', 'UsersController@register');
+use App\Http\Middleware\UserRegisterFormMiddleware;
+Route::get('/users/register', 'UsersController@register')
+    ->middleware(UserRegisterFormMiddleware::class);


### PR DESCRIPTION
* app/Http/Middleware/UserRegisterFormMiddleware.php
会員登録フォームの作成に必要な、inputタグの属性値の定義を、コントローラからミドルウェアへ移植
* routes/web.php
/users/register へのリクエスト時のルーティングに、UserRegisterFormMiddlewareクラスの使用を宣言
* app/Http/Controllers/UsersController.php
registerアクションの実行前に、UserRegisterFormMiddlewareから$requestの受け取り、viewへ渡すように修正